### PR TITLE
Alternative action

### DIFF
--- a/EDSideBar/EDSideBar.h
+++ b/EDSideBar/EDSideBar.h
@@ -22,6 +22,7 @@
 @required
 - (void)sideBar:(EDSideBar*)tabBar didSelectButton:(NSInteger)index;
 @end
+
 enum {
 	ECSideBarLayoutTop			= 0,
 	ECSideBarLayoutCenter		= 1,
@@ -29,10 +30,8 @@ enum {
 };	
 typedef NSUInteger ECSideBarLayoutMode;
 
-@interface EDSideBar : NSView {
-
-
-
+@interface EDSideBar : NSView
+{
 	ECSideBarLayoutMode layoutMode;
 	NSColor *_backgroundColor;
 	CGFloat	buttonsHeight;
@@ -48,10 +47,12 @@ typedef NSUInteger ECSideBarLayoutMode;
 -(void)addButtonWithTitle:(NSString*)title;
 -(void)addButtonWithTitle:(NSString*)title image:(NSImage*)image;
 -(void)addButtonWithTitle:(NSString*)title image:(NSImage*)image alternateImage:(NSImage*)alternateImage;
+-(void)setTarget:(id)aTarget withSelector:(SEL)aSelector atIndex:(NSInteger)anIndex;
 -(void)selectButtonAtRow:(NSUInteger)row;
 -(void)drawBackground:(NSRect)rect;
 -(void)setSelectionImage:(NSImage*)image;
 -(id)cellForItem:(NSInteger)index;
+-(NSInteger)selectedIndex;
 
 @property (EDSideBarRetain) NSColor *backgroundColor;
 @property (EDSideBarRetain) id<EDSideBarDelegate>sidebarDelegate;

--- a/EDSideBar/EDSideBar.h
+++ b/EDSideBar/EDSideBar.h
@@ -19,7 +19,7 @@
 #endif
 
 @protocol EDSideBarDelegate <NSObject>
-@required
+@optional
 - (void)sideBar:(EDSideBar*)tabBar didSelectButton:(NSInteger)index;
 @end
 

--- a/EDSideBar/EDSideBar.h
+++ b/EDSideBar/EDSideBar.h
@@ -49,6 +49,8 @@ typedef NSUInteger ECSideBarLayoutMode;
 -(void)addButtonWithTitle:(NSString*)title image:(NSImage*)image alternateImage:(NSImage*)alternateImage;
 -(void)setTarget:(id)aTarget withSelector:(SEL)aSelector atIndex:(NSInteger)anIndex;
 -(void)selectButtonAtRow:(NSUInteger)row;
+-(void)selectNext;
+-(void)selectPrev;
 -(void)drawBackground:(NSRect)rect;
 -(void)setSelectionImage:(NSImage*)image;
 -(id)cellForItem:(NSInteger)index;

--- a/EDSideBar/EDSideBar.m
+++ b/EDSideBar/EDSideBar.m
@@ -327,8 +327,12 @@
     if ([cell isKindOfClass:[ECSideBarButtonCell class]]) {
         ECSideBarButtonCell *ecCell = (ECSideBarButtonCell *) cell;
         
-        if (ecCell.realTarget && ecCell.realAction) {
+        if (ecCell.realTarget && ecCell.realAction &&
+            [ecCell.realTarget respondsToSelector:ecCell.realAction]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
             [ecCell.realTarget performSelector:ecCell.realAction withObject:self];
+#pragma clang diagnostic pop            
             return;
         }
     }

--- a/EDSideBar/EDSideBar.m
+++ b/EDSideBar/EDSideBar.m
@@ -338,6 +338,26 @@
 	}
 }
 
+-(void)selectNext
+{
+    NSInteger row = [_matrix selectedRow] + 1;
+    if (row >= [_matrix.cells count])
+        return;
+    
+    [_matrix selectCellAtRow:row column:0];
+    [self buttonClicked:self];
+}
+
+-(void)selectPrev
+{
+    NSInteger row = [_matrix selectedRow] - 1;
+    if (row <= 0)
+        return;
+    
+    [_matrix selectCellAtRow:row column:0];
+    [self buttonClicked:self];
+}
+
 -(NSInteger)selectedIndex
 {
     return [_matrix selectedRow];

--- a/Sample/EDSidebarAppDelegate.m
+++ b/Sample/EDSidebarAppDelegate.m
@@ -53,6 +53,7 @@
 	// Add a bit of noise texture
     sideBarDefault.noiseAlpha=0.04;
     
+    [sideBarDefault setTarget:self withSelector:@selector(logThis:) atIndex:0];
     
 	// Setup sidebar with blackCell (BlackCell)
 	// Buttons centered. Selection is not animated
@@ -78,6 +79,11 @@
 	NSLog(@"Button selected: %lu", button );
 	[textField setStringValue:str];
 	
+}
+
+- (IBAction)logThis:(id)sender
+{
+    NSLog(@"here I am");
 }
 
 @end

--- a/Sample/EDSidebarAppDelegate.m
+++ b/Sample/EDSidebarAppDelegate.m
@@ -84,6 +84,7 @@
 - (IBAction)logThis:(id)sender
 {
     NSLog(@"here I am");
+    [sideBarDefault selectNext];
 }
 
 @end


### PR DESCRIPTION
In my project I really need to assign a target/action to a sidebar item, so I added the method `setTarget:withSelector:atIndex` to accomplish: when user clicks on an item, a message is sent to its target if any, otherwise a notification is sent to its delegate (normal behavior).

A minor change is the helper method `selectedIndex` which returns selected item index.
