### PR TITLE
Changed ECSideBarLayoutMode to NS_ENUM for better Swift support.

### DIFF
--- a/EDSideBar/EDSideBar.h
+++ b/EDSideBar/EDSideBar.h
@@ -23,12 +23,11 @@
 - (void)sideBar:(EDSideBar*)tabBar didSelectButton:(NSInteger)index;
 @end
 
-enum {
+typedef NS_ENUM(NSUInteger, ECSideBarLayoutMode) {
 	ECSideBarLayoutTop			= 0,
 	ECSideBarLayoutCenter		= 1,
 	ECSideBarLayoutBottom		= 2,
-};	
-typedef NSUInteger ECSideBarLayoutMode;
+};
 
 @interface EDSideBar : NSView
 {


### PR DESCRIPTION
For Swift to do its bridging magic, enums need to be defined with the NS_ENUM macro.
