### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ EDSideBar
 Attemp to create a Sidebar in ObjectiveC/Cocoa like those seen in apps like Sparrow Mail, Twitter or Github for Mac.
 
 
-###Installation
+### Installation
 
 The easiest way to install EDSidebar is via [CocoaPods](http://cocoapods.org). Add this line to your Podfile:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
